### PR TITLE
Added settings window

### DIFF
--- a/Data/Settings/BotSettings.cs
+++ b/Data/Settings/BotSettings.cs
@@ -50,6 +50,13 @@ namespace HD
         return instance._twitter;
       }
     }
+
+    public static bool IsConfigured => ((twitch.botOauth 
+                                         ?? twitch.botUsername 
+                                         ?? twitch.channelOauth 
+                                         ?? twitch.channelUsername 
+                                         ?? twitch.clientId) != null);
+
     #endregion
 
     #region Public Write

--- a/Data/Settings/TwitchSettings.cs
+++ b/Data/Settings/TwitchSettings.cs
@@ -34,7 +34,6 @@ namespace HD
       set
       {
         _channelUsername = value;
-        BotSettings.Save();
       }
     }
 
@@ -47,7 +46,6 @@ namespace HD
       set
       {
         _clientId = value;
-        BotSettings.Save();
       }
     }
 
@@ -63,7 +61,6 @@ namespace HD
       set
       {
         _channelOauth = value;
-        BotSettings.Save();
       }
     }
 
@@ -76,7 +73,6 @@ namespace HD
       set
       {
         _botUsername = value;
-        BotSettings.Save();
       }
     }
 
@@ -92,7 +88,6 @@ namespace HD
       set
       {
         _botOauth = value;
-        BotSettings.Save();
       }
     }
     #endregion

--- a/Data/Settings/TwitterSettings.cs
+++ b/Data/Settings/TwitterSettings.cs
@@ -34,7 +34,6 @@ namespace HD
       set
       {
         _consumerKey = value;
-        BotSettings.Save();
       }
     }
 
@@ -47,7 +46,6 @@ namespace HD
       set
       {
         _consumerSecret = value;
-        BotSettings.Save();
       }
     }
 
@@ -60,7 +58,6 @@ namespace HD
       set
       {
         _accessToken = value;
-        BotSettings.Save();
       }
     }
 
@@ -73,7 +70,6 @@ namespace HD
       set
       {
         _accessTokenSecret = value;
-        BotSettings.Save();
       }
     }
     #endregion

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -4,11 +4,30 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:HD"
+        xmlns:fa="http://schemas.fontawesome.io/icons/"
         mc:Ignorable="d"
-        Title="Bot" Height="191.673" Width="530.634" Loaded="Window_Loaded" Closing="Window_Closing" Background="Black" Topmost="True" WindowStyle="ToolWindow">
+        Title="Bot" Height="190" Width="530" Loaded="Window_Loaded" Closing="Window_Closing" Background="Black" Topmost="True" WindowStyle="ToolWindow">
     <Grid>
-        <TextBox x:Name="Message" Margin="10,52,10,10" TextWrapping="Wrap" FontSize="18" FontFamily="Verdana" Background="Black" Foreground="White" SelectionBrush="#FFE1EEFB" KeyDown="Message_KeyDown" PreviewKeyDown="Message_PreviewKeyDown"/>
-        <TextBox x:Name="Title" Margin="10,10,10,115" TextWrapping="Wrap" FontSize="18" FontFamily="Verdana" Background="Black" Foreground="White" SelectionBrush="#FFE1EEFB" Loaded="Title_Loaded" LostFocus="Title_LostFocus"/>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="40"/>
+        </Grid.ColumnDefinitions>
+        <TextBox Grid.Row="0" x:Name="Title" Margin="5" TextWrapping="Wrap" FontSize="18" FontFamily="Verdana" Background="Black" Foreground="White" SelectionBrush="#FFE1EEFB" Loaded="Title_Loaded" LostFocus="Title_LostFocus"/>
+        <TextBox Grid.Row="1" Grid.ColumnSpan="2" x:Name="Message" Margin="5" TextWrapping="Wrap" FontSize="18" FontFamily="Verdana" Background="Black" Foreground="White" SelectionBrush="#FFE1EEFB" KeyDown="Message_KeyDown" PreviewKeyDown="Message_PreviewKeyDown"/>
 
+        <Button fa:Awesome.Content="Cog" 
+                x:Name="OpenSettings" 
+                Grid.Row="0" 
+                Margin="5"
+                BorderThickness="0"
+                Foreground="White"
+                Background="Black"
+                Grid.Column="1" 
+                Click="OpenSettings_OnClick"
+                TextElement.FontFamily="pack://application:,,,/FontAwesome.WPF;component/#FontAwesome"/>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -23,7 +23,24 @@ namespace HD
       object sender,
       RoutedEventArgs e)
     {
+      CheckBotSettings();
       TwitchController.Start();
+    }
+
+    private void CheckBotSettings()
+    {
+      Hide();
+      if (BotSettings.IsConfigured == false)
+      {
+        MessageBox.Show("Your twitch settings are not configured properly. Please setup.", 
+          "ChatBot",
+          MessageBoxButton.OK,
+          MessageBoxImage.Exclamation);
+
+        if (new SettingsWindow().ShowDialog() == false)
+          Environment.Exit(0);
+      }
+      Show();
     }
 
     void Window_Closing(
@@ -111,6 +128,12 @@ namespace HD
       RoutedEventArgs e)
     {
       BotLogic.streamTitle = Title.Text;
+    }
+
+    private void OpenSettings_OnClick(object sender, RoutedEventArgs e)
+    {
+      if (new SettingsWindow().ShowDialog() == false)
+        Environment.Exit(0);
     }
   }
 }

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -1,0 +1,65 @@
+﻿<Window x:Class="HD.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:ChatBot"
+        mc:Ignorable="d"
+        Title="SettingsWindow" WindowStartupLocation="CenterScreen" Closing="SettingsWindow_OnClosing" Height="300" Width="400">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="35"/>
+        </Grid.RowDefinitions>
+        <TabControl Grid.Row="0">
+            <TabItem Header="Twitch SettingsWindow">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="120"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
+                    </Grid.RowDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0" Margin="3">Channel Username</Label>
+                    <TextBox x:Name="ChannelUsername" Grid.Row="0" Grid.Column="1" Margin="3"></TextBox>
+                    <Label Grid.Row="1" Grid.Column="0" Margin="3">Channel OAuth</Label>
+                    <TextBox x:Name="ChannelOAuth" Grid.Row="1" Grid.Column="1" Margin="3"></TextBox>
+                    <Label Grid.Row="2" Grid.Column="0" Margin="3">Bot Username</Label>
+                    <TextBox x:Name="BotUsername" Grid.Row="2" Grid.Column="1" Margin="3"></TextBox>
+                    <Label Grid.Row="3" Grid.Column="0" Margin="3">Bot OAuth</Label>
+                    <TextBox x:Name="BotOAuth" Grid.Row="3" Grid.Column="1" Margin="3"></TextBox>
+                    <Label Grid.Row="4" Grid.Column="0" Margin="3">Client ID</Label>
+                    <TextBox x:Name="ClientId" Grid.Row="4" Grid.Column="1" Margin="3"></TextBox>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Twitter SettingsWindow">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="120"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
+                    </Grid.RowDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0" Margin="3">Consumer Key</Label>
+                    <TextBox x:Name="ConsumerKey" Grid.Row="0" Grid.Column="1" Margin="3"></TextBox>
+                    <Label Grid.Row="1" Grid.Column="0" Margin="3">Consumer Secret</Label>
+                    <TextBox x:Name="ConsumerSecret" Grid.Row="1" Grid.Column="1" Margin="3"></TextBox>
+                    <Label Grid.Row="2" Grid.Column="0" Margin="3">Access Token</Label>
+                    <TextBox x:Name="AccessToken" Grid.Row="2" Grid.Column="1" Margin="3"></TextBox>
+                    <Label Grid.Row="3" Grid.Column="0" Margin="3">Access Token Secret</Label>
+                    <TextBox x:Name="AccessTokenSecret" Grid.Row="3" Grid.Column="1" Margin="3"></TextBox>
+                </Grid>
+            </TabItem>
+        </TabControl>
+        <Button x:Name="SaveButton" Click="SaveButton_OnClick" Grid.Row="1" Margin="3">Save</Button>
+    </Grid>
+</Window>

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -47,6 +47,8 @@ namespace HD
 
     private void SaveSettings()
     {
+      // Save twitter anyways, since there is no validation yet.
+      SaveTwitter();
       if (CheckSettings() == false)
       {
         _settingsSaved = false;
@@ -59,7 +61,6 @@ namespace HD
       }
 
       SaveTwitch();
-      SaveTwitter();
       _settingsSaved = true;
 
       DialogResult = _settingsSaved;

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -1,0 +1,123 @@
+﻿using System.ComponentModel;
+using System.Windows;
+
+namespace HD
+{
+  /// <summary>
+  /// Interaction logic for SettingsWindow.xaml
+  /// </summary>
+  public partial class SettingsWindow : Window
+  {
+    private bool _settingsSaved = true;
+    public SettingsWindow()
+    {
+      InitializeComponent();
+      LoadSettings();
+      if (CheckSettings() == false)
+        _settingsSaved = false;
+    }
+
+    private void LoadSettings()
+    {
+      LoadTwitch();
+      LoadTwitter();
+    }
+
+    private void LoadTwitter()
+    {
+      ConsumerKey.Text = BotSettings.twitter.consumerKey;
+      ConsumerSecret.Text = BotSettings.twitter.consumerSecret;
+      AccessToken.Text = BotSettings.twitter.accessToken;
+      AccessTokenSecret.Text = BotSettings.twitter.accessTokenSecret;
+    }
+
+    private void LoadTwitch()
+    {
+      BotOAuth.Text = BotSettings.twitch.botOauth;
+      BotUsername.Text = BotSettings.twitch.botUsername;
+      ChannelOAuth.Text = BotSettings.twitch.channelOauth;
+      ChannelUsername.Text = BotSettings.twitch.channelUsername;
+      ClientId.Text = BotSettings.twitch.clientId;
+    }
+
+    private void SaveButton_OnClick(object sender, RoutedEventArgs e)
+    {
+      SaveSettings();
+    }
+
+    private void SaveSettings()
+    {
+      if (CheckSettings() == false)
+      {
+        _settingsSaved = false;
+        MessageBox.Show("Please insert all values for twitch\r\n\r\n" +
+                        "Otherwise the bot can't start.",
+                        "ChatBot",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Exclamation);
+        return;
+      }
+
+      SaveTwitch();
+      SaveTwitter();
+      _settingsSaved = true;
+
+      DialogResult = _settingsSaved;
+      Close();
+    }
+
+    private void SaveTwitch()
+    {
+      BotSettings.twitch.botOauth = BotOAuth.Text;
+      BotSettings.twitch.botUsername = BotUsername.Text;
+      BotSettings.twitch.channelOauth = ChannelOAuth.Text;
+      BotSettings.twitch.channelUsername = ChannelUsername.Text;
+      BotSettings.twitch.clientId = ClientId.Text;
+      BotSettings.Save();
+    }
+
+    private void SaveTwitter()
+    {
+      BotSettings.twitter.consumerKey = ConsumerKey.Text;
+      BotSettings.twitter.consumerSecret = ConsumerSecret.Text;
+      BotSettings.twitter.accessToken = AccessToken.Text;
+      BotSettings.twitter.accessTokenSecret = AccessTokenSecret.Text;
+      BotSettings.Save();
+    }
+
+    private bool CheckSettings()
+    { // we can later add validation for twitter settings
+      return CheckTwitchSettings();
+    }
+
+    private bool CheckTwitchSettings()
+    {
+      return !string.IsNullOrEmpty(BotOAuth.Text) &&
+             !string.IsNullOrEmpty(BotUsername.Text) &&
+             !string.IsNullOrEmpty(ChannelOAuth.Text) &&
+             !string.IsNullOrEmpty(ChannelUsername.Text) &&
+             !string.IsNullOrEmpty(ClientId.Text);
+    }
+
+    private void SettingsWindow_OnClosing(object sender, CancelEventArgs e)
+    {
+      if (_settingsSaved)
+      {
+        DialogResult = _settingsSaved;
+        return;
+      }
+
+      if (MessageBox.Show("The bot is not configured properly. " +
+                          "Close application?", "ChatBot",
+                          MessageBoxButton.YesNo,
+                          MessageBoxImage.Exclamation) == MessageBoxResult.Yes)
+      {
+        DialogResult = false;
+      }
+      else
+      {
+        e.Cancel = true;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Things done:

- Removed "Save()" on every property setter in settings classes because I don't want to write to the file anytime I change a variable. If it is something you need, we should have a seperate function that saves in one write.

- On application startup, the settings will be checked. If the twitch settings are invalid (e.g. the user did not enter anything), the user has to enter the twitch details. (Careful: None of the fields are masked right now). If the user does not enter anything and tries to close the window, the application will gracefully ask to enter the details or shutdown the application.

- Added FontAwesome.WPF (https://github.com/charri/Font-Awesome-WPF) for having nice forms later. Already used as the settings button on the main window. You are not a UI guy right? 😅 

Anyways, I am not really happy with the implementation since it goes against every MVVM rule, but I think this is a discussion we have to take on another time.

Also: I have explicitly excluded the App.config, ChatBot.csproj and the packages.config. I think it might break your/others workspace.